### PR TITLE
feat: use u128 for serde to avoid excess length info

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -243,8 +243,7 @@ mod serde_support {
             value.parse::<Self::Value>().map_err(de::Error::custom)
         }
 
-        fn visit_i128<E>(self,v:i128) -> Result<Self::Value,E>where E:de::Error, {
-            let v = v as u128;
+        fn visit_u128<E>(self,v: u128) -> Result<Self::Value,E>where E:de::Error, {
             Ok(Self::Value::from(v))
         }
 


### PR DESCRIPTION
This PR uses u128 for serialization instead of bare bytes because for serializers like bincode, it will add extra 8 bytes of length info for byte sequence, which, in this case, is unnecessary.